### PR TITLE
EnumPointer class and typedef

### DIFF
--- a/lib/ffi-icu/chardet.rb
+++ b/lib/ffi-icu/chardet.rb
@@ -49,14 +49,9 @@ module ICU
       end
 
       def detectable_charsets
-        enum_ptr = Lib.check_error do |ptr|
-          Lib.ucsdet_getAllDetectableCharsets(@detector, ptr)
+        Lib.check_error do |status|
+          Lib.ucsdet_getAllDetectableCharsets(@detector, status).to_a
         end
-
-        result = Lib.enum_ptr_to_array(enum_ptr)
-        Lib.uenum_close(enum_ptr)
-
-        result
       end
 
       private

--- a/lib/ffi-icu/collation.rb
+++ b/lib/ffi-icu/collation.rb
@@ -6,15 +6,13 @@ module ICU
     end
 
     def self.keywords
-      enum_ptr = Lib.check_error { |error| Lib.ucol_getKeywords(error) }
-      keywords = Lib.enum_ptr_to_array(enum_ptr)
-      Lib.uenum_close enum_ptr
+      keywords = Lib.check_error { |error| Lib.ucol_getKeywords(error).to_a }
 
       hash = {}
       keywords.each do |keyword|
-        enum_ptr = Lib.check_error { |error| Lib.ucol_getKeywordValues(keyword, error) }
-        hash[keyword] = Lib.enum_ptr_to_array(enum_ptr)
-        Lib.uenum_close(enum_ptr)
+        hash[keyword] = Lib.check_error do |error|
+          Lib.ucol_getKeywordValues(keyword, error).to_a
+        end
       end
 
       hash

--- a/lib/ffi-icu/locale.rb
+++ b/lib/ffi-icu/locale.rb
@@ -127,13 +127,7 @@ module ICU
     end
 
     def keywords
-      enum_ptr = Lib.check_error { |status| Lib.uloc_openKeywords(@id, status) }
-
-      begin
-        Lib.enum_ptr_to_array(enum_ptr)
-      ensure
-        Lib.uenum_close(enum_ptr)
-      end
+      Lib.check_error { |status| Lib.uloc_openKeywords(@id, status).to_a }
     end
 
     def language

--- a/lib/ffi-icu/transliteration.rb
+++ b/lib/ffi-icu/transliteration.rb
@@ -9,14 +9,7 @@ module ICU
       alias_method :translit, :transliterate
 
       def available_ids
-        enum_ptr = Lib.check_error do |error|
-          Lib.utrans_openIDs(error)
-        end
-
-        result = Lib.enum_ptr_to_array(enum_ptr)
-        Lib.uenum_close(enum_ptr)
-
-        result
+        Lib.check_error { |error| Lib.utrans_openIDs(error).to_a }
       end
     end
 


### PR DESCRIPTION
Inheriting from `AutoPointer` ensures the `uenum_close` is always called. I couldn't figure out how instantiate an `EnumPointer` to test this in RSpec, but printing from the `release` method confirms that it is indeed wired correctly.