### PR TITLE
Treat ‘length’ in UCharBuffer as number of UChars.

### DIFF
--- a/lib/ffi-icu/number_formatting.rb
+++ b/lib/ffi-icu/number_formatting.rb
@@ -81,7 +81,7 @@ module ICU
               needed_length = Lib.unum_format_int64(@f, number, out_ptr, needed_length, nil, error)
             end
           end
-          out_ptr.string
+          out_ptr.string needed_length
         rescue BufferOverflowError
           raise BufferOverflowError, "needed: #{needed_length}" if retried
           out_ptr = out_ptr.resized_to needed_length
@@ -115,7 +115,7 @@ module ICU
 
         begin
           Lib.check_error do |error|
-            needed_length = Lib.unum_format_currency(@f, number, UCharPointer.from_string(currency, 3), out_ptr, needed_length, nil, error)
+            needed_length = Lib.unum_format_currency(@f, number, UCharPointer.from_string(currency, 4), out_ptr, needed_length, nil, error)
           end
           out_ptr.string
         rescue BufferOverflowError

--- a/lib/ffi-icu/transliteration.rb
+++ b/lib/ffi-icu/transliteration.rb
@@ -23,8 +23,6 @@ module ICU
     class Transliterator
 
       def initialize(id, rules = nil, direction = :forward)
-        warn 'the ffi-icu transliteration support is broken, see https://github.com/jarib/ffi-icu/issues/15'
-
         rules_length = 0
 
         if rules
@@ -47,8 +45,8 @@ module ICU
         # this is a bit unpleasant
 
         unicode_size = from.unpack("U*").size
-        capacity     = from.bytesize + 1
-        buf          = UCharPointer.from_string(from)
+        capacity     = unicode_size + 1
+        buf          = UCharPointer.from_string(from, capacity)
         limit        = FFI::MemoryPointer.new :int32
         text_length  = FFI::MemoryPointer.new :int32
 

--- a/lib/ffi-icu/uchar.rb
+++ b/lib/ffi-icu/uchar.rb
@@ -6,20 +6,19 @@ module ICU
 
     def self.from_string(str, capacity = nil)
       str   = str.encode("UTF-8") if str.respond_to? :encode
-      bytes = str.unpack("U*")
+      chars = str.unpack("U*")
 
       if capacity
-        capacity *= TYPE_SIZE
-        if capacity < bytes.size
-          raise ArgumentError, "capacity is too small for string of #{bytes.size} bytes"
+        if capacity < chars.size
+          raise ArgumentError, "capacity is too small for string of #{chars.size} UChars"
         end
 
         ptr = new capacity
       else
-        ptr = new bytes.size
+        ptr = new chars.size
       end
 
-      ptr.write_array_of_uint16 bytes
+      ptr.write_array_of_uint16 chars
 
       ptr
     end

--- a/spec/transliteration_spec.rb
+++ b/spec/transliteration_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 module ICU
-  describe Transliteration::Transliterator, broken: true do
+  describe Transliteration::Transliterator do
     def transliterator_for(*args)
       Transliteration::Transliterator.new(*args)
     end
@@ -11,7 +11,8 @@ module ICU
     [
       ["Any-Hex", "abcde", "\\u0061\\u0062\\u0063\\u0064\\u0065"],
       ["Lower", "ABC", "abc"],
-      ["en", "雙屬性集合之空間分群演算法-應用於地理資料", "shuāng shǔ xìng jí hé zhī kōng jiān fēn qún yǎn suàn fǎ-yīng yòng yú de lǐ zī liào"]
+      ["en", "雙屬性集合之空間分群演算法-應用於地理資料", "shuāng shǔ xìng jí hé zhī kōng jiān fēn qún yǎn suàn fǎ-yīng yòng yú de lǐ zī liào"],
+      ["Devanagari-Latin", "दौलत", "daulata"]
     ].each do |id, input, output|
       it "should transliterate #{id}" do
         tl = transliterator_for(id)
@@ -21,7 +22,7 @@ module ICU
     end
   end # Transliterator
 
-  describe Transliteration, broken: true do
+  describe Transliteration do
     it "should provide a list of available ids" do
       ids = ICU::Transliteration.available_ids
       ids.should be_kind_of(Array)

--- a/spec/uchar_spec.rb
+++ b/spec/uchar_spec.rb
@@ -17,7 +17,7 @@ module ICU
 
     it 'takes an optional capacity' do
       ptr = UCharPointer.from_string('abc', 5)
-      ptr.size.should == 20
+      ptr.size.should == 10
     end
 
     describe 'converting to string' do


### PR DESCRIPTION
Fixes buffer overflows on OS X.