### PR TITLE
Supports embedded null bytes

### DIFF
--- a/lib/ffi-icu/chardet.rb
+++ b/lib/ffi-icu/chardet.rb
@@ -73,7 +73,8 @@ module ICU
 
       def set_text(text)
         Lib.check_error do |status|
-          Lib.ucsdet_setText(@detector, text, text.bytesize, status)
+          data = FFI::MemoryPointer.from_string(text)
+          Lib.ucsdet_setText(@detector, data, text.bytesize, status)
         end
       end
 

--- a/lib/ffi-icu/lib.rb
+++ b/lib/ffi-icu/lib.rb
@@ -262,7 +262,7 @@ module ICU
 
     attach_function :ucsdet_open,                     "ucsdet_open#{suffix}",                      [:pointer], :pointer
     attach_function :ucsdet_close,                    "ucsdet_close#{suffix}",                     [:pointer], :void
-    attach_function :ucsdet_setText,                  "ucsdet_setText#{suffix}",                   [:pointer,  :string,   :int32_t,  :pointer], :void
+    attach_function :ucsdet_setText,                  "ucsdet_setText#{suffix}",                   [:pointer,  :pointer,  :int32_t,  :pointer], :void
     attach_function :ucsdet_setDeclaredEncoding,      "ucsdet_setDeclaredEncoding#{suffix}",       [:pointer,  :string,   :int32_t,  :pointer], :void
     attach_function :ucsdet_detect,                   "ucsdet_detect#{suffix}",                    [:pointer,  :pointer], :pointer
     attach_function :ucsdet_detectAll,                "ucsdet_detectAll#{suffix}",                 [:pointer,  :pointer,  :pointer], :pointer

--- a/spec/chardet_spec.rb
+++ b/spec/chardet_spec.rb
@@ -34,4 +34,11 @@ describe ICU::CharDet::Detector do
     detector.detect_all("foo bar").should be_instance_of(Array)
   end
 
+  it "should support null bytes" do
+    # Create a utf-16 string and then force it to binary (ascii) to mimic data from net/http
+    string = "foo".encode("UTF-16").force_encoding("binary")
+    m = detector.detect(string)
+    m.name.should == "UTF-16BE"
+    m.language.should be_kind_of(String)
+  end
 end


### PR DESCRIPTION
Supports embedded null characters when detecting encodings.  This comes up when using net/http. Assume a response body contains an xml document encoded in utf-16.  Net/http will say its encoding is assci-us and thus calling #detect will raise an exception due to the embedded null bytes.