### PR TITLE
add support for Time Formatting/Parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,27 @@ Examples:
     curf.format(1234.56, 'USD') #=> "$1,234.56"
 ```
 
+Time Formatting/Parsing
+--------------------------
+
+Examples:
+
+```ruby
+    # class method interface
+    f = ICU::TimeFormatting.format(Time.mktime(2015, 11, 12, 15, 21, 16), {:locale => 'cs_CZ', :zone => 'Europe/Prague', :date => :short, :time => :short})
+    f #=> "12.11.15 15:21"
+
+    # reusable formatting objects
+    formater = ICU::TimeFormatting.create(:locale => 'cs_CZ', :zone => 'Europe/Prague', :date => :long , :time => :none)
+    formater.format(Time.now)  #=> "25. února 2015"
+```
+
+```ruby
+    # reusable formatting objects
+    formater = ICU::TimeFormatting.create(:locale => 'cs_CZ', :zone => 'Europe/Prague', :date => :long , :time => :none)
+    formater.parse("25. února 2015") #=> Wed Feb 25 00:00:00 +0100 2015
+```
+
 Tested on:
 ==========
 

--- a/lib/ffi-icu.rb
+++ b/lib/ffi-icu.rb
@@ -40,4 +40,5 @@ require "ffi-icu/transliteration"
 require "ffi-icu/normalization"
 require "ffi-icu/break_iterator"
 require "ffi-icu/number_formatting"
+require "ffi-icu/time_formatting"
 

--- a/lib/ffi-icu/lib.rb
+++ b/lib/ffi-icu/lib.rb
@@ -421,6 +421,8 @@ module ICU
     attach_function :udat_close, "unum_close#{suffix}", [:pointer], :void
     attach_function :udat_format, "udat_format#{suffix}", [:pointer, :double, :pointer, :int32_t, :pointer, :pointer], :int32_t
     attach_function :udat_parse, "udat_parse#{suffix}", [:pointer, :pointer, :int32_t,  :pointer, :pointer], :double
+    attach_function :udat_toPattern, "udat_toPattern#{suffix}", [:pointer, :bool    , :pointer, :int32_t    , :pointer], :int32_t
+    attach_function :udat_applyPattern, "udat_applyPattern#{suffix}", [:pointer, :bool    , :pointer, :int32_t     ], :void
     # tz
     attach_function :ucal_setDefaultTimeZone, "ucal_setDefaultTimeZone#{suffix}", [:pointer, :pointer], :int32_t
     attach_function :ucal_getDefaultTimeZone, "ucal_getDefaultTimeZone#{suffix}", [:pointer, :int32_t, :pointer], :int32_t

--- a/lib/ffi-icu/lib.rb
+++ b/lib/ffi-icu/lib.rb
@@ -409,6 +409,21 @@ module ICU
     end
     attach_function :unum_format_currency, "unum_formatDoubleCurrency#{suffix}", [:pointer, :double, :pointer, :pointer, :int32_t, :pointer, :pointer], :int32_t
     attach_function :unum_set_attribute, "unum_setAttribute#{suffix}", [:pointer, :number_format_attribute, :int32_t], :void
+    # date
+    enum :date_format_style, [
+      :none,  -1,
+      :full,   0,
+      :long,   1,
+      :medium, 2,
+      :short,  3,
+    ]
+    attach_function :udat_open, "udat_open#{suffix}", [:date_format_style, :date_format_style, :string, :pointer, :int32_t, :pointer, :int32_t, :pointer ], :pointer
+    attach_function :udat_close, "unum_close#{suffix}", [:pointer], :void
+    attach_function :udat_format, "udat_format#{suffix}", [:pointer, :double, :pointer, :int32_t, :pointer, :pointer], :int32_t
+    attach_function :udat_parse, "udat_parse#{suffix}", [:pointer, :pointer, :int32_t,  :pointer, :pointer], :double
+    # tz
+    attach_function :ucal_setDefaultTimeZone, "ucal_setDefaultTimeZone#{suffix}", [:pointer, :pointer], :int32_t
+    attach_function :ucal_getDefaultTimeZone, "ucal_getDefaultTimeZone#{suffix}", [:pointer, :int32_t, :pointer], :int32_t
 
   end # Lib
 end # ICU

--- a/lib/ffi-icu/time_formatting.rb
+++ b/lib/ffi-icu/time_formatting.rb
@@ -32,14 +32,14 @@ module ICU
         time_zone = nil
         d_len = 0
         if time_zone_str
-            time_zone = UCharPointer.from_string(time_zone_str)
-            d_len = time_zone_str.size
+          time_zone = UCharPointer.from_string(time_zone_str)
+          d_len = time_zone_str.size
         else
-            Lib.check_error { | error| 
-                i_len  = 150
-                time_zone = UCharPointer.new(i_len)
-                d_len = Lib.ucal_getDefaultTimeZone(time_zone, i_len, error) 
-            }
+          Lib.check_error { | error| 
+            i_len  = 150
+            time_zone = UCharPointer.new(i_len)
+            d_len = Lib.ucal_getDefaultTimeZone(time_zone, i_len, error) 
+          }
         end
         ptr = Lib.check_error { | error| Lib.udat_open(time_style, date_style, locale, time_zone, d_len, FFI::MemoryPointer.new(4), -1, error) }
         FFI::AutoPointer.new(ptr, Lib.method(:udat_close))
@@ -54,20 +54,20 @@ module ICU
         tz_style   = options[:tz_style]
         time_zone  = options[:zone]
         @f = make_formatter(time_style, date_style, locale, time_zone)
-	if tz_style
-	    f0 = get_date_format(true)
-	    f1 = update_tz_format(f0, tz_style)    
-	    if f1 != f0
-		set_date_format(true, f1)
-            end
-	end
+        if tz_style
+          f0 = get_date_format(true)
+          f1 = update_tz_format(f0, tz_style)    
+          if f1 != f0
+            set_date_format(true, f1)
+          end
+        end
       end
       def parse(str)
           str_u = UCharPointer.from_string(str)
           str_l = str_u.size
           Lib.check_error do |error|
-              ret = Lib.udat_parse(@f, str_u, str_l, nil, error)
-              Time.at(ret / 1000.0)
+            ret = Lib.udat_parse(@f, str_u, str_l, nil, error)
+            Time.at(ret / 1000.0)
           end
       end
 
@@ -96,53 +96,53 @@ module ICU
       end
       # time-zone formating
       def update_tz_format(format, tz_style)
-          return format if format !~ /(.*?)(\s*(?:[zZOVV]+\s*))(.*?)/
-          pre, tz, suff = $1, $2, $3
-          if tz_style == :none
-      	tz = ((tz =~ /\s/) && !pre.empty? && !suff.empty?) ? ' ' : ''
-          else
-      	$tz_map ||= {
-                 :generic_location =>   'VVVV',# The generic location format.
-                                               #   Where that is unavailable, falls back to the long localized GMT format ("OOOO";
-                                               #   Note: Fallback is only necessary with a GMT-style Time Zone ID, like Etc/GMT-830.),
-                                               #   This is especially useful when presenting possible timezone choices for user selection,
-                                               #   since the naming is more uniform than the "v" format.
-                                               #   such as "United States Time (New York)", "Italy Time"
-                 :generic_long     =>  'vvvv', # The long generic non-location format.
-                                               #   Where that is unavailable, falls back to generic location format ("VVVV")., such as "Eastern Time".
-                 :generic_short    =>     'v', # The short generic non-location format.
-                                               #   Where that is unavailable, falls back to the generic location format ("VVVV"),
-                                               #   then the short localized GMT format as the final fallback., such as "ET".
-                 :specific_long    =>  'zzzz', # The long specific non-location format.
-                                               #   Where that is unavailable, falls back to the long localized GMT format ("OOOO").
-                 :specific_short   =>     'z', # The short specific non-location format.
-                                               #   Where that is unavailable, falls back to the short localized GMT format ("O").
-                 :basic            =>     'Z', # The ISO8601 basic format with hours, minutes and optional seconds fields.
-                                               #   The format is equivalent to RFC 822 zone format (when optional seconds field is absent).
-                                               #   This is equivalent to the "xxxx" specifier.
-                 :localized_long   =>  'ZZZZ', # The long localized GMT format. This is equivalent to the "OOOO" specifier, such as GMT-8:00
-                 :extended         => 'ZZZZZ', # The ISO8601 extended format with hours, minutes and optional seconds fields.
-                                               #   The ISO8601 UTC indicator "Z" is used when local time offset is 0.
-                                               #   This is equivalent to the "XXXXX" specifier, such as -08:00 -07:52:58
-                 :localized_short  =>    'O',  # The short localized GMT format, such as GMT-8
-                 :localized_longO  => 'OOOO',  # The long localized GMT format, such as GMT-08:00
-                 :tz_id_short      =>    'V',  # The short time zone ID. Where that is unavailable,
-                                               #   the special short time zone ID unk (Unknown Zone) is used.
-                                               #   Note: This specifier was originally used for a variant of the short specific non-location format,
-                                               #   but it was deprecated in the later version of this specification. In CLDR 23, the definition
-                                               #   of the specifier was changed to designate a short time zone ID, such as uslax	
-                 :tz_id_long       =>   'VV',  # The long time zone ID, such as America/Los_Angeles
-                 :city_location    =>  'VVV',  # The exemplar city (location) for the time zone. Where that is unavailable,
-                                               #   the localized exemplar city name for the special zone Etc/Unknown is used as the fallback
-                                               #   (for example, "Unknown City"), such as Los Angeles	
-      	# see: http://unicode.org/reports/tr35/tr35-dates.html#Date_Format_Patterns
-      	}
-      	repl = $tz_map[tz_style]
+        return format if format !~ /(.*?)(\s*(?:[zZOVV]+\s*))(.*?)/
+        pre, tz, suff = $1, $2, $3
+        if tz_style == :none
+          tz = ((tz =~ /\s/) && !pre.empty? && !suff.empty?) ? ' ' : ''
+        else
+          $tz_map ||= {
+            :generic_location =>   'VVVV',# The generic location format.
+                                          #   Where that is unavailable, falls back to the long localized GMT format ("OOOO";
+                                          #   Note: Fallback is only necessary with a GMT-style Time Zone ID, like Etc/GMT-830.),
+                                          #   This is especially useful when presenting possible timezone choices for user selection,
+                                          #   since the naming is more uniform than the "v" format.
+                                          #   such as "United States Time (New York)", "Italy Time"
+            :generic_long     =>  'vvvv', # The long generic non-location format.
+                                          #   Where that is unavailable, falls back to generic location format ("VVVV")., such as "Eastern Time".
+            :generic_short    =>     'v', # The short generic non-location format.
+                                          #   Where that is unavailable, falls back to the generic location format ("VVVV"),
+                                          #   then the short localized GMT format as the final fallback., such as "ET".
+            :specific_long    =>  'zzzz', # The long specific non-location format.
+                                          #   Where that is unavailable, falls back to the long localized GMT format ("OOOO").
+            :specific_short   =>     'z', # The short specific non-location format.
+                                          #   Where that is unavailable, falls back to the short localized GMT format ("O").
+            :basic            =>     'Z', # The ISO8601 basic format with hours, minutes and optional seconds fields.
+                                          #   The format is equivalent to RFC 822 zone format (when optional seconds field is absent).
+                                          #   This is equivalent to the "xxxx" specifier.
+            :localized_long   =>  'ZZZZ', # The long localized GMT format. This is equivalent to the "OOOO" specifier, such as GMT-8:00
+            :extended         => 'ZZZZZ', # The ISO8601 extended format with hours, minutes and optional seconds fields.
+                                          #   The ISO8601 UTC indicator "Z" is used when local time offset is 0.
+                                          #   This is equivalent to the "XXXXX" specifier, such as -08:00 -07:52:58
+            :localized_short  =>    'O',  # The short localized GMT format, such as GMT-8
+            :localized_longO  => 'OOOO',  # The long localized GMT format, such as GMT-08:00
+            :tz_id_short      =>    'V',  # The short time zone ID. Where that is unavailable,
+                                          #   the special short time zone ID unk (Unknown Zone) is used.
+                                          #   Note: This specifier was originally used for a variant of the short specific non-location format,
+                                          #   but it was deprecated in the later version of this specification. In CLDR 23, the definition
+                                          #   of the specifier was changed to designate a short time zone ID, such as uslax
+            :tz_id_long       =>   'VV',  # The long time zone ID, such as America/Los_Angeles
+            :city_location    =>  'VVV',  # The exemplar city (location) for the time zone. Where that is unavailable,
+                                          #   the localized exemplar city name for the special zone Etc/Unknown is used as the fallback
+                                          #   (for example, "Unknown City"), such as Los Angeles
+            # see: http://unicode.org/reports/tr35/tr35-dates.html#Date_Format_Patterns
+          }
+          repl = $tz_map[tz_style]
           raise 'no such tz_style' unless repl
-      	tz.gsub!(/^(\s*)(.*?)(\s*)$/, '\1'+repl+'\3')
-          end
-          return pre + tz + suff
-          format
+          tz.gsub!(/^(\s*)(.*?)(\s*)$/, '\1'+repl+'\3')
+        end
+        return pre + tz + suff
+        format
       end
 
       def get_date_format(localized=true)

--- a/lib/ffi-icu/time_formatting.rb
+++ b/lib/ffi-icu/time_formatting.rb
@@ -41,6 +41,7 @@ module ICU
             d_len = Lib.ucal_getDefaultTimeZone(time_zone, i_len, error) 
           }
         end
+
         ptr = Lib.check_error { | error| Lib.udat_open(time_style, date_style, locale, time_zone, d_len, FFI::MemoryPointer.new(4), -1, error) }
         FFI::AutoPointer.new(ptr, Lib.method(:udat_close))
       end
@@ -62,6 +63,7 @@ module ICU
           end
         end
       end
+
       def parse(str)
           str_u = UCharPointer.from_string(str)
           str_l = str_u.size
@@ -86,6 +88,7 @@ module ICU
               needed_length = Lib.udat_format(@f, dt.to_f * 1000.0, out_ptr, needed_length, nil, error)
             end
           end
+
           out_ptr.string
         rescue BufferOverflowError
           raise BufferOverflowError, "needed: #{needed_length}" if retried
@@ -94,6 +97,7 @@ module ICU
           retry
         end
       end
+
       # time-zone formating
       def update_tz_format(format, tz_style)
         return format if format !~ /(.*?)(\s*(?:[zZOVV]+\s*))(.*?)/
@@ -101,7 +105,7 @@ module ICU
         if tz_style == :none
           tz = ((tz =~ /\s/) && !pre.empty? && !suff.empty?) ? ' ' : ''
         else
-          $tz_map ||= {
+          @@tz_map ||= {
             :generic_location =>   'VVVV',# The generic location format.
                                           #   Where that is unavailable, falls back to the long localized GMT format ("OOOO";
                                           #   Note: Fallback is only necessary with a GMT-style Time Zone ID, like Etc/GMT-830.),
@@ -141,8 +145,7 @@ module ICU
           raise 'no such tz_style' unless repl
           tz.gsub!(/^(\s*)(.*?)(\s*)$/, '\1'+repl+'\3')
         end
-        return pre + tz + suff
-        format
+        pre + tz + suff
       end
 
       def get_date_format(localized=true)
@@ -155,6 +158,7 @@ module ICU
           Lib.check_error do |error|
             needed_length = Lib.udat_toPattern(@f, localized, out_ptr, needed_length, error)
           end
+
           out_ptr.string
         rescue BufferOverflowError
           raise BufferOverflowError, "needed: #{needed_length}" if retried
@@ -163,6 +167,7 @@ module ICU
           retry
         end
       end
+
       def set_date_format(localized, pattern_str)
         pattern     = UCharPointer.from_string(pattern_str)
         pattern_len = pattern_str.size

--- a/lib/ffi-icu/time_formatting.rb
+++ b/lib/ffi-icu/time_formatting.rb
@@ -141,7 +141,7 @@ module ICU
                                           #   (for example, "Unknown City"), such as Los Angeles
             # see: http://unicode.org/reports/tr35/tr35-dates.html#Date_Format_Patterns
           }
-          repl = $tz_map[tz_style]
+          repl = @@tz_map[tz_style]
           raise 'no such tz_style' unless repl
           tz.gsub!(/^(\s*)(.*?)(\s*)$/, '\1'+repl+'\3')
         end

--- a/lib/ffi-icu/time_formatting.rb
+++ b/lib/ffi-icu/time_formatting.rb
@@ -51,10 +51,17 @@ module ICU
         time_style = options[:time]   || :short
         date_style = options[:date]   || :short
         locale     = options[:locale] || 'C'
+        tz_style   = options[:tz_style]
         time_zone  = options[:zone]
         @f = make_formatter(time_style, date_style, locale, time_zone)
+	if tz_style
+	    f0 = get_date_format(true)
+	    f1 = update_tz_format(f0, tz_style)    
+	    if f1 != f0
+		set_date_format(true, f1)
+            end
+	end
       end
-
       def parse(str)
           str_u = UCharPointer.from_string(str)
           str_l = str_u.size
@@ -85,6 +92,83 @@ module ICU
           out_ptr = out_ptr.resized_to needed_length
           retried = true
           retry
+        end
+      end
+      # time-zone formating
+      def update_tz_format(format, tz_style)
+          return format if format !~ /(.*?)(\s*(?:[zZOVV]+\s*))(.*?)/
+          pre, tz, suff = $1, $2, $3
+          if tz_style == :none
+      	tz = ((tz =~ /\s/) && !pre.empty? && !suff.empty?) ? ' ' : ''
+          else
+      	$tz_map ||= {
+                 :generic_location =>   'VVVV',# The generic location format.
+                                               #   Where that is unavailable, falls back to the long localized GMT format ("OOOO";
+                                               #   Note: Fallback is only necessary with a GMT-style Time Zone ID, like Etc/GMT-830.),
+                                               #   This is especially useful when presenting possible timezone choices for user selection,
+                                               #   since the naming is more uniform than the "v" format.
+                                               #   such as "United States Time (New York)", "Italy Time"
+                 :generic_long     =>  'vvvv', # The long generic non-location format.
+                                               #   Where that is unavailable, falls back to generic location format ("VVVV")., such as "Eastern Time".
+                 :generic_short    =>     'v', # The short generic non-location format.
+                                               #   Where that is unavailable, falls back to the generic location format ("VVVV"),
+                                               #   then the short localized GMT format as the final fallback., such as "ET".
+                 :specific_long    =>  'zzzz', # The long specific non-location format.
+                                               #   Where that is unavailable, falls back to the long localized GMT format ("OOOO").
+                 :specific_short   =>     'z', # The short specific non-location format.
+                                               #   Where that is unavailable, falls back to the short localized GMT format ("O").
+                 :basic            =>     'Z', # The ISO8601 basic format with hours, minutes and optional seconds fields.
+                                               #   The format is equivalent to RFC 822 zone format (when optional seconds field is absent).
+                                               #   This is equivalent to the "xxxx" specifier.
+                 :localized_long   =>  'ZZZZ', # The long localized GMT format. This is equivalent to the "OOOO" specifier, such as GMT-8:00
+                 :extended         => 'ZZZZZ', # The ISO8601 extended format with hours, minutes and optional seconds fields.
+                                               #   The ISO8601 UTC indicator "Z" is used when local time offset is 0.
+                                               #   This is equivalent to the "XXXXX" specifier, such as -08:00 -07:52:58
+                 :localized_short  =>    'O',  # The short localized GMT format, such as GMT-8
+                 :localized_longO  => 'OOOO',  # The long localized GMT format, such as GMT-08:00
+                 :tz_id_short      =>    'V',  # The short time zone ID. Where that is unavailable,
+                                               #   the special short time zone ID unk (Unknown Zone) is used.
+                                               #   Note: This specifier was originally used for a variant of the short specific non-location format,
+                                               #   but it was deprecated in the later version of this specification. In CLDR 23, the definition
+                                               #   of the specifier was changed to designate a short time zone ID, such as uslax	
+                 :tz_id_long       =>   'VV',  # The long time zone ID, such as America/Los_Angeles
+                 :city_location    =>  'VVV',  # The exemplar city (location) for the time zone. Where that is unavailable,
+                                               #   the localized exemplar city name for the special zone Etc/Unknown is used as the fallback
+                                               #   (for example, "Unknown City"), such as Los Angeles	
+      	# see: http://unicode.org/reports/tr35/tr35-dates.html#Date_Format_Patterns
+      	}
+      	repl = $tz_map[tz_style]
+          raise 'no such tz_style' unless repl
+      	tz.gsub!(/^(\s*)(.*?)(\s*)$/, '\1'+repl+'\3')
+          end
+          return pre + tz + suff
+          format
+      end
+
+      def get_date_format(localized=true)
+        needed_length = 0
+        out_ptr = UCharPointer.new(needed_length)
+
+        retried = false
+
+        begin
+          Lib.check_error do |error|
+            needed_length = Lib.udat_toPattern(@f, localized, out_ptr, needed_length, error)
+          end
+          out_ptr.string
+        rescue BufferOverflowError
+          raise BufferOverflowError, "needed: #{needed_length}" if retried
+          out_ptr = out_ptr.resized_to needed_length
+          retried = true
+          retry
+        end
+      end
+      def set_date_format(localized, pattern_str)
+        pattern     = UCharPointer.from_string(pattern_str)
+        pattern_len = pattern_str.size
+
+        Lib.check_error do |error|
+          needed_length = Lib.udat_applyPattern(@f, localized, pattern, pattern_len)
         end
       end
     end # DateTimeFormatter

--- a/lib/ffi-icu/time_formatting.rb
+++ b/lib/ffi-icu/time_formatting.rb
@@ -1,0 +1,92 @@
+
+module ICU
+  module TimeFormatting
+    @default_options = {}
+    
+    def self.create(options = {})
+      DateTimeFormatter.new(@default_options.merge(options))
+    end
+
+    def self.clear_default_options
+      @default_options.clear
+    end
+
+    def self.set_default_options(options)
+      @default_options.merge!(options)
+    end
+
+    def self.format(dt, options = {})
+      create(@default_options.merge(options)).format(dt)
+    end
+
+    class BaseFormatter
+
+      def set_attributes(options)
+        options.each { |key, value| Lib.unum_set_attribute(@f, key, value) }
+        self
+      end
+
+      private
+
+      def make_formatter(time_style, date_style, locale, time_zone_str)
+        time_zone = nil
+        d_len = 0
+        if time_zone_str
+            time_zone = UCharPointer.from_string(time_zone_str)
+            d_len = time_zone_str.size
+        else
+            Lib.check_error { | error| 
+                i_len  = 150
+                time_zone = UCharPointer.new(i_len)
+                d_len = Lib.ucal_getDefaultTimeZone(time_zone, i_len, error) 
+            }
+        end
+        ptr = Lib.check_error { | error| Lib.udat_open(time_style, date_style, locale, time_zone, d_len, FFI::MemoryPointer.new(4), -1, error) }
+        FFI::AutoPointer.new(ptr, Lib.method(:udat_close))
+      end
+    end
+
+    class DateTimeFormatter < BaseFormatter
+      def initialize(options={})
+        time_style = options[:time]   || :short
+        date_style = options[:date]   || :short
+        locale     = options[:locale] || 'C'
+        time_zone  = options[:zone]
+        @f = make_formatter(time_style, date_style, locale, time_zone)
+      end
+
+      def parse(str)
+          str_u = UCharPointer.from_string(str)
+          str_l = str_u.size
+          Lib.check_error do |error|
+              ret = Lib.udat_parse(@f, str_u, str_l, nil, error)
+              Time.at(ret / 1000.0)
+          end
+      end
+
+      def format(dt)
+        needed_length = 0
+        out_ptr = UCharPointer.new(needed_length)
+
+        retried = false
+
+        begin
+          Lib.check_error do |error|
+            case dt
+            when Date
+              needed_length = Lib.udat_format(@f, Time.mktime( dt.year, dt.month, dt.day, 0, 0, 0, 0 ).to_f * 1000.0, out_ptr, needed_length, nil, error)
+            when Time
+              needed_length = Lib.udat_format(@f, dt.to_f * 1000.0, out_ptr, needed_length, nil, error)
+            end
+          end
+          out_ptr.string
+        rescue BufferOverflowError
+          raise BufferOverflowError, "needed: #{needed_length}" if retried
+          out_ptr = out_ptr.resized_to needed_length
+          retried = true
+          retry
+        end
+      end
+    end # DateTimeFormatter
+  end # Formatting
+end # ICU

--- a/spec/time_spec.rb
+++ b/spec/time_spec.rb
@@ -15,7 +15,11 @@ module ICU
       t7 = Time.at(1427593043) # in TZ=Europe/Prague Time.mktime(2015, 03, 29, 03, 37, 23)
       t8 = Time.at(1427596704) # in TZ=Europe/Prague Time.mktime(2015, 03, 29, 04, 38, 24)
 
-      f1 = TimeFormatting.create(:locale => 'cs_CZ', :zone => 'Europe/Prague', :date => :long , :time => :long)
+      f1 = TimeFormatting.create(:locale => 'cs_CZ', :zone => 'Europe/Prague', :date => :long , :time => :long, :tz_style => :localized_long)
+      it 'check date_format for lang=cs_CZ' do
+            f1.get_date_format(true).should eql "d. MMMM y H:mm:ss ZZZZ"
+            f1.get_date_format(false).should eql "d. MMMM y H:mm:ss ZZZZ"
+      end
       it "for lang=cs_CZ zone=Europe/Prague" do
           f1.should be_an_instance_of TimeFormatting::DateTimeFormatter
           f1.format(t0).should eql "12. listopadu 2015 15:21:16 GMT+01:00"
@@ -29,17 +33,29 @@ module ICU
           f1.format(t8).should eql "29. března 2015 4:38:24 GMT+02:00"
       end
 
-      f2 = TimeFormatting.create(:locale => 'en_US', :zone => 'Europe/Moscow', :date => :short , :time => :long)
+      f2 = TimeFormatting.create(:locale => 'en_US', :zone => 'Europe/Moscow', :date => :short , :time => :long, :tz_style => :generic_location)
+      cldr_version = Lib.cldr_version.to_s
+      en_tz  = "Moscow Time"
+      en_sep = ","
+      if cldr_version <= "2.0.1"
+        en_tz  = "Russia Time (Moscow)"
+        en_sep = ""
+      end
+      en_exp = "M/d/yy#{en_sep} h:mm:ss a VVVV"
+      it 'check date_format for lang=en_US' do
+            f2.get_date_format(true).should eql en_exp
+            f2.get_date_format(false).should eql en_exp
+      end
       it "lang=en_US zone=Europe/Moscow" do
-          f2.format(t0).should eql "11/12/15 6:21:16 PM GMT+04:00"
-          f2.format(t1).should eql "10/25/15 3:15:17 AM GMT+04:00"
-          f2.format(t2).should eql "10/25/15 5:16:18 AM GMT+04:00"
-          f2.format(t3).should eql "10/25/15 6:17:19 AM GMT+04:00"
-          f2.format(t4).should eql "10/25/15 7:18:20 AM GMT+04:00"
-          f2.format(t5).should eql "3/29/15 4:35:21 AM GMT+04:00"
-          f2.format(t6).should eql "3/29/15 5:36:22 AM GMT+04:00"
-          f2.format(t7).should eql "3/29/15 5:37:23 AM GMT+04:00"
-          f2.format(t8).should eql "3/29/15 6:38:24 AM GMT+04:00"
+          f2.format(t0).should eql "11/12/15#{en_sep} 6:21:16 PM #{en_tz}"
+          f2.format(t1).should eql "10/25/15#{en_sep} 3:15:17 AM #{en_tz}"
+          f2.format(t2).should eql "10/25/15#{en_sep} 5:16:18 AM #{en_tz}"
+          f2.format(t3).should eql "10/25/15#{en_sep} 6:17:19 AM #{en_tz}"
+          f2.format(t4).should eql "10/25/15#{en_sep} 7:18:20 AM #{en_tz}"
+          f2.format(t5).should eql "3/29/15#{en_sep} 4:35:21 AM #{en_tz}"
+          f2.format(t6).should eql "3/29/15#{en_sep} 5:36:22 AM #{en_tz}"
+          f2.format(t7).should eql "3/29/15#{en_sep} 5:37:23 AM #{en_tz}"
+          f2.format(t8).should eql "3/29/15#{en_sep} 6:38:24 AM #{en_tz}"
       end
 
       f3 = TimeFormatting.create(:locale => 'de_DE', :zone => 'Africa/Dakar ', :date => :short , :time => :long)

--- a/spec/time_spec.rb
+++ b/spec/time_spec.rb
@@ -17,8 +17,8 @@ module ICU
 
       f1 = TimeFormatting.create(:locale => 'cs_CZ', :zone => 'Europe/Prague', :date => :long , :time => :long, :tz_style => :localized_long)
       it 'check date_format for lang=cs_CZ' do
-        f1.get_date_format(true).should eql "d. MMMM y H:mm:ss ZZZZ"
-        f1.get_date_format(false).should eql "d. MMMM y H:mm:ss ZZZZ"
+        f1.date_format(true).should eql "d. MMMM y H:mm:ss ZZZZ"
+        f1.date_format(false).should eql "d. MMMM y H:mm:ss ZZZZ"
       end
 
       it "for lang=cs_CZ zone=Europe/Prague" do
@@ -45,8 +45,8 @@ module ICU
 
       en_exp = "M/d/yy#{en_sep} h:mm:ss a VVVV"
       it 'check date_format for lang=en_US' do
-        f2.get_date_format(true).should eql en_exp
-        f2.get_date_format(false).should eql en_exp
+        f2.date_format(true).should eql en_exp
+        f2.date_format(false).should eql en_exp
       end
 
       it "lang=en_US zone=Europe/Moscow" do

--- a/spec/time_spec.rb
+++ b/spec/time_spec.rb
@@ -1,0 +1,61 @@
+# encoding: UTF-8
+
+require 'spec_helper'
+
+module ICU
+  describe TimeFormatting do
+    describe 'the TimeFormatting ' do
+      t0 = Time.at(1447338076) # in TZ=Europe/Prague Time.mktime(2015, 11, 12, 15, 21, 16)
+      t1 = Time.at(1445728517) # in TZ=Europe/Prague Time.mktime(2015, 10, 25, 01, 15, 17)
+      t2 = Time.at(1445735778) # in TZ=Europe/Prague Time.mktime(2015, 10, 25, 02, 16, 18)
+      t3 = Time.at(1445739439) # in TZ=Europe/Prague Time.mktime(2015, 10, 25, 03, 17, 19)
+      t4 = Time.at(1445743100) # in TZ=Europe/Prague Time.mktime(2015, 10, 25, 04, 18, 20)
+      t5 = Time.at(1427589321) # in TZ=Europe/Prague Time.mktime(2015, 03, 29, 01, 35, 21)
+      t6 = Time.at(1427592982) # in TZ=Europe/Prague Time.mktime(2015, 03, 29, 02, 36, 22)
+      t7 = Time.at(1427593043) # in TZ=Europe/Prague Time.mktime(2015, 03, 29, 03, 37, 23)
+      t8 = Time.at(1427596704) # in TZ=Europe/Prague Time.mktime(2015, 03, 29, 04, 38, 24)
+
+      f1 = TimeFormatting.create(:locale => 'cs_CZ', :zone => 'Europe/Prague', :date => :long , :time => :long)
+      it "for lang=cs_CZ zone=Europe/Prague" do
+          f1.should be_an_instance_of TimeFormatting::DateTimeFormatter
+          f1.format(t0).should eql "12. listopadu 2015 15:21:16 GMT+01:00"
+          f1.format(t1).should eql "25. října 2015 1:15:17 GMT+02:00"
+          f1.format(t2).should eql "25. října 2015 2:16:18 GMT+01:00"
+          f1.format(t3).should eql "25. října 2015 3:17:19 GMT+01:00"
+          f1.format(t4).should eql "25. října 2015 4:18:20 GMT+01:00"
+          f1.format(t5).should eql "29. března 2015 1:35:21 GMT+01:00"
+          f1.format(t6).should eql "29. března 2015 3:36:22 GMT+02:00"
+          f1.format(t7).should eql "29. března 2015 3:37:23 GMT+02:00"
+          f1.format(t8).should eql "29. března 2015 4:38:24 GMT+02:00"
+      end
+
+      f2 = TimeFormatting.create(:locale => 'en_US', :zone => 'Europe/Moscow', :date => :short , :time => :long)
+      it "lang=en_US zone=Europe/Moscow" do
+          f2.format(t0).should eql "11/12/15 6:21:16 PM GMT+04:00"
+          f2.format(t1).should eql "10/25/15 3:15:17 AM GMT+04:00"
+          f2.format(t2).should eql "10/25/15 5:16:18 AM GMT+04:00"
+          f2.format(t3).should eql "10/25/15 6:17:19 AM GMT+04:00"
+          f2.format(t4).should eql "10/25/15 7:18:20 AM GMT+04:00"
+          f2.format(t5).should eql "3/29/15 4:35:21 AM GMT+04:00"
+          f2.format(t6).should eql "3/29/15 5:36:22 AM GMT+04:00"
+          f2.format(t7).should eql "3/29/15 5:37:23 AM GMT+04:00"
+          f2.format(t8).should eql "3/29/15 6:38:24 AM GMT+04:00"
+      end
+
+      f3 = TimeFormatting.create(:locale => 'de_DE', :zone => 'Africa/Dakar ', :date => :short , :time => :long)
+      it "lang=de_DE zone=Africa/Dakar" do
+          f3.format(t0).should eql "12.11.15 14:21:16 GMT"
+          f3.format(t1).should eql "24.10.15 23:15:17 GMT"
+          f3.format(t2).should eql "25.10.15 01:16:18 GMT"
+          f3.format(t3).should eql "25.10.15 02:17:19 GMT"
+          f3.format(t4).should eql "25.10.15 03:18:20 GMT"
+          f3.format(t5).should eql "29.03.15 00:35:21 GMT"
+          f3.format(t6).should eql "29.03.15 01:36:22 GMT"
+          f3.format(t7).should eql "29.03.15 01:37:23 GMT"
+          f3.format(t8).should eql "29.03.15 02:38:24 GMT"
+      end
+
+    end
+  end
+end
+

--- a/spec/time_spec.rb
+++ b/spec/time_spec.rb
@@ -20,6 +20,7 @@ module ICU
         f1.get_date_format(true).should eql "d. MMMM y H:mm:ss ZZZZ"
         f1.get_date_format(false).should eql "d. MMMM y H:mm:ss ZZZZ"
       end
+
       it "for lang=cs_CZ zone=Europe/Prague" do
         f1.should be_an_instance_of TimeFormatting::DateTimeFormatter
         f1.format(t0).should eql "12. listopadu 2015 15:21:16 GMT+01:00"
@@ -41,11 +42,13 @@ module ICU
         en_tz  = "Russia Time (Moscow)"
         en_sep = ""
       end
+
       en_exp = "M/d/yy#{en_sep} h:mm:ss a VVVV"
       it 'check date_format for lang=en_US' do
         f2.get_date_format(true).should eql en_exp
         f2.get_date_format(false).should eql en_exp
       end
+
       it "lang=en_US zone=Europe/Moscow" do
         f2.format(t0).should eql "11/12/15#{en_sep} 6:21:16 PM #{en_tz}"
         f2.format(t1).should eql "10/25/15#{en_sep} 3:15:17 AM #{en_tz}"
@@ -70,7 +73,6 @@ module ICU
         f3.format(t7).should eql "29.03.15 01:37:23 GMT"
         f3.format(t8).should eql "29.03.15 02:38:24 GMT"
       end
-
     end
   end
 end

--- a/spec/time_spec.rb
+++ b/spec/time_spec.rb
@@ -17,20 +17,20 @@ module ICU
 
       f1 = TimeFormatting.create(:locale => 'cs_CZ', :zone => 'Europe/Prague', :date => :long , :time => :long, :tz_style => :localized_long)
       it 'check date_format for lang=cs_CZ' do
-            f1.get_date_format(true).should eql "d. MMMM y H:mm:ss ZZZZ"
-            f1.get_date_format(false).should eql "d. MMMM y H:mm:ss ZZZZ"
+        f1.get_date_format(true).should eql "d. MMMM y H:mm:ss ZZZZ"
+        f1.get_date_format(false).should eql "d. MMMM y H:mm:ss ZZZZ"
       end
       it "for lang=cs_CZ zone=Europe/Prague" do
-          f1.should be_an_instance_of TimeFormatting::DateTimeFormatter
-          f1.format(t0).should eql "12. listopadu 2015 15:21:16 GMT+01:00"
-          f1.format(t1).should eql "25. října 2015 1:15:17 GMT+02:00"
-          f1.format(t2).should eql "25. října 2015 2:16:18 GMT+01:00"
-          f1.format(t3).should eql "25. října 2015 3:17:19 GMT+01:00"
-          f1.format(t4).should eql "25. října 2015 4:18:20 GMT+01:00"
-          f1.format(t5).should eql "29. března 2015 1:35:21 GMT+01:00"
-          f1.format(t6).should eql "29. března 2015 3:36:22 GMT+02:00"
-          f1.format(t7).should eql "29. března 2015 3:37:23 GMT+02:00"
-          f1.format(t8).should eql "29. března 2015 4:38:24 GMT+02:00"
+        f1.should be_an_instance_of TimeFormatting::DateTimeFormatter
+        f1.format(t0).should eql "12. listopadu 2015 15:21:16 GMT+01:00"
+        f1.format(t1).should eql "25. října 2015 1:15:17 GMT+02:00"
+        f1.format(t2).should eql "25. října 2015 2:16:18 GMT+01:00"
+        f1.format(t3).should eql "25. října 2015 3:17:19 GMT+01:00"
+        f1.format(t4).should eql "25. října 2015 4:18:20 GMT+01:00"
+        f1.format(t5).should eql "29. března 2015 1:35:21 GMT+01:00"
+        f1.format(t6).should eql "29. března 2015 3:36:22 GMT+02:00"
+        f1.format(t7).should eql "29. března 2015 3:37:23 GMT+02:00"
+        f1.format(t8).should eql "29. března 2015 4:38:24 GMT+02:00"
       end
 
       f2 = TimeFormatting.create(:locale => 'en_US', :zone => 'Europe/Moscow', :date => :short , :time => :long, :tz_style => :generic_location)
@@ -43,32 +43,32 @@ module ICU
       end
       en_exp = "M/d/yy#{en_sep} h:mm:ss a VVVV"
       it 'check date_format for lang=en_US' do
-            f2.get_date_format(true).should eql en_exp
-            f2.get_date_format(false).should eql en_exp
+        f2.get_date_format(true).should eql en_exp
+        f2.get_date_format(false).should eql en_exp
       end
       it "lang=en_US zone=Europe/Moscow" do
-          f2.format(t0).should eql "11/12/15#{en_sep} 6:21:16 PM #{en_tz}"
-          f2.format(t1).should eql "10/25/15#{en_sep} 3:15:17 AM #{en_tz}"
-          f2.format(t2).should eql "10/25/15#{en_sep} 5:16:18 AM #{en_tz}"
-          f2.format(t3).should eql "10/25/15#{en_sep} 6:17:19 AM #{en_tz}"
-          f2.format(t4).should eql "10/25/15#{en_sep} 7:18:20 AM #{en_tz}"
-          f2.format(t5).should eql "3/29/15#{en_sep} 4:35:21 AM #{en_tz}"
-          f2.format(t6).should eql "3/29/15#{en_sep} 5:36:22 AM #{en_tz}"
-          f2.format(t7).should eql "3/29/15#{en_sep} 5:37:23 AM #{en_tz}"
-          f2.format(t8).should eql "3/29/15#{en_sep} 6:38:24 AM #{en_tz}"
+        f2.format(t0).should eql "11/12/15#{en_sep} 6:21:16 PM #{en_tz}"
+        f2.format(t1).should eql "10/25/15#{en_sep} 3:15:17 AM #{en_tz}"
+        f2.format(t2).should eql "10/25/15#{en_sep} 5:16:18 AM #{en_tz}"
+        f2.format(t3).should eql "10/25/15#{en_sep} 6:17:19 AM #{en_tz}"
+        f2.format(t4).should eql "10/25/15#{en_sep} 7:18:20 AM #{en_tz}"
+        f2.format(t5).should eql "3/29/15#{en_sep} 4:35:21 AM #{en_tz}"
+        f2.format(t6).should eql "3/29/15#{en_sep} 5:36:22 AM #{en_tz}"
+        f2.format(t7).should eql "3/29/15#{en_sep} 5:37:23 AM #{en_tz}"
+        f2.format(t8).should eql "3/29/15#{en_sep} 6:38:24 AM #{en_tz}"
       end
 
       f3 = TimeFormatting.create(:locale => 'de_DE', :zone => 'Africa/Dakar ', :date => :short , :time => :long)
       it "lang=de_DE zone=Africa/Dakar" do
-          f3.format(t0).should eql "12.11.15 14:21:16 GMT"
-          f3.format(t1).should eql "24.10.15 23:15:17 GMT"
-          f3.format(t2).should eql "25.10.15 01:16:18 GMT"
-          f3.format(t3).should eql "25.10.15 02:17:19 GMT"
-          f3.format(t4).should eql "25.10.15 03:18:20 GMT"
-          f3.format(t5).should eql "29.03.15 00:35:21 GMT"
-          f3.format(t6).should eql "29.03.15 01:36:22 GMT"
-          f3.format(t7).should eql "29.03.15 01:37:23 GMT"
-          f3.format(t8).should eql "29.03.15 02:38:24 GMT"
+        f3.format(t0).should eql "12.11.15 14:21:16 GMT"
+        f3.format(t1).should eql "24.10.15 23:15:17 GMT"
+        f3.format(t2).should eql "25.10.15 01:16:18 GMT"
+        f3.format(t3).should eql "25.10.15 02:17:19 GMT"
+        f3.format(t4).should eql "25.10.15 03:18:20 GMT"
+        f3.format(t5).should eql "29.03.15 00:35:21 GMT"
+        f3.format(t6).should eql "29.03.15 01:36:22 GMT"
+        f3.format(t7).should eql "29.03.15 01:37:23 GMT"
+        f3.format(t8).should eql "29.03.15 02:38:24 GMT"
       end
 
     end


### PR DESCRIPTION
Hi, I expect, that it's OK now.

I'm prepared to push next two pull requests, if You will find it usefull:
1) compatible changes to run on ruby1.8 and 1.9.1
2) files need to build .deb package (works on wheezy with ruby1.8 and 1.9.1 and libicu48 and on jessie with ruby2.1 and libicu52)