### PR TITLE
Add new normalization api support

### DIFF
--- a/lib/ffi-icu.rb
+++ b/lib/ffi-icu.rb
@@ -38,7 +38,7 @@ require "ffi-icu/collation"
 require "ffi-icu/locale"
 require "ffi-icu/transliteration"
 require "ffi-icu/normalization"
+require "ffi-icu/normalizer"
 require "ffi-icu/break_iterator"
 require "ffi-icu/number_formatting"
 require "ffi-icu/time_formatting"
-

--- a/lib/ffi-icu/lib.rb
+++ b/lib/ffi-icu/lib.rb
@@ -339,6 +339,13 @@ module ICU
 
     attach_function :unorm_normalize, "unorm_normalize#{suffix}", [:pointer, :int32_t, :normalization_mode, :int32_t, :pointer, :int32_t, :pointer], :int32_t
 
+    # http://icu-project.org/apiref/icu4c/unorm2_8h.html
+
+    enum :normalization2_mode, [ :compose, :decompose, :fcd, :compose_contiguous ]
+    attach_function :unorm2_getInstance, "unorm2_getInstance#{suffix}", [:pointer, :pointer, :normalization2_mode, :pointer], :pointer
+    attach_function :unorm2_normalize, "unorm2_normalize#{suffix}", [:pointer, :pointer, :int32_t, :pointer, :int32_t, :pointer], :int32_t
+    attach_function :unorm2_isNormalized, "unorm2_isNormalized#{suffix}", [:pointer, :pointer, :int32_t, :pointer], :bool
+
     #
     # Text Boundary Analysis
     #
@@ -392,10 +399,10 @@ module ICU
       :ignore
     ]
     enum :number_format_attribute, [
-       :parse_int_only, :grouping_used, :decimal_always_show, :max_integer_digits, 
-       :min_integer_digits, :integer_digits, :max_fraction_digits, :min_fraction_digits, 
-       :fraction_digits, :multiplier, :grouping_size, :rounding_mode, 
-       :rounding_increment, :format_width, :padding_position, :secondary_grouping_size, 
+       :parse_int_only, :grouping_used, :decimal_always_show, :max_integer_digits,
+       :min_integer_digits, :integer_digits, :max_fraction_digits, :min_fraction_digits,
+       :fraction_digits, :multiplier, :grouping_size, :rounding_mode,
+       :rounding_increment, :format_width, :padding_position, :secondary_grouping_size,
        :significant_digits_used, :min_significant_digits, :max_significant_digits, :lenient_parse
     ]
     attach_function :unum_open, "unum_open#{suffix}", [:number_format_style, :pointer, :int32_t, :string, :pointer, :pointer ], :pointer

--- a/lib/ffi-icu/normalizer.rb
+++ b/lib/ffi-icu/normalizer.rb
@@ -1,0 +1,47 @@
+module ICU
+  class Normalizer
+    # support for newer ICU normalization API
+
+    def initialize(package_name = nil, name = 'nfc', mode = :decompose)
+      Lib.check_error do |error|
+        @instance = Lib.unorm2_getInstance(package_name, name, mode, error)
+      end
+    end
+
+    def normalize(input)
+      input_length  = input.jlength
+      in_ptr        = UCharPointer.from_string(input)
+      needed_length = capacity = 0
+      out_ptr       = UCharPointer.new(needed_length)
+
+      retried = false
+      begin
+        Lib.check_error do |error|
+          needed_length = Lib.unorm2_normalize(@instance, in_ptr, input_length, out_ptr, capacity, error)
+        end
+      rescue BufferOverflowError
+        raise BufferOverflowError, "needed: #{needed_length}" if retried
+
+        capacity = needed_length
+        out_ptr = out_ptr.resized_to needed_length
+
+        retried = true
+        retry
+      end
+
+      out_ptr.string
+    end
+
+    def is_normailzed?(input)
+      input_length  = input.jlength
+      in_ptr        = UCharPointer.from_string(input)
+
+      Lib.check_error do |error|
+        result = Lib.unorm2_isNormalized(@instance, in_ptr, input_length, error)
+      end
+
+      result
+    end
+
+  end # Normalizer
+end # ICU

--- a/spec/normalizer_spec.rb
+++ b/spec/normalizer_spec.rb
@@ -1,0 +1,59 @@
+# encoding: UTF-8
+
+require 'spec_helper'
+
+module ICU
+  describe Normalizer do
+    describe 'NFD: nfc decompose' do
+      let(:normalizer) { ICU::Normalizer.new(nil, 'nfc', :decompose) }
+
+      it "should normalize a string" do
+        normalizer.normalize("Å").unpack("U*").should == [65, 778]
+        normalizer.normalize("ô").unpack("U*").should == [111, 770]
+        normalizer.normalize("a").unpack("U*").should == [97]
+        normalizer.normalize("中文").unpack("U*").should == [20013, 25991]
+        normalizer.normalize("Äffin").unpack("U*").should == [65, 776, 102, 102, 105, 110]
+        normalizer.normalize("Äﬃn").unpack("U*").should == [65, 776, 64259, 110]
+        normalizer.normalize("Henry IV").unpack("U*").should == [72, 101, 110, 114, 121, 32, 73, 86]
+        normalizer.normalize("Henry Ⅳ").unpack("U*").should == [72, 101, 110, 114, 121, 32, 8547]
+      end
+    end
+
+    describe 'NFC: nfc compose' do
+      let(:normalizer) { ICU::Normalizer.new(nil, 'nfc', :compose) }
+
+      it "should normalize a string" do
+        normalizer.normalize("Å").unpack("U*").should == [197]
+        normalizer.normalize("ô").unpack("U*").should == [244]
+        normalizer.normalize("a").unpack("U*").should == [97]
+        normalizer.normalize("中文").unpack("U*").should == [20013, 25991]
+        normalizer.normalize("Äffin").unpack("U*").should == [196, 102, 102, 105, 110]
+        normalizer.normalize("Äﬃn").unpack("U*").should == [196, 64259, 110]
+        normalizer.normalize("Henry IV").unpack("U*").should == [72, 101, 110, 114, 121, 32, 73, 86]
+        normalizer.normalize("Henry Ⅳ").unpack("U*").should == [72, 101, 110, 114, 121, 32, 8547]
+      end
+    end
+
+    describe 'NFKD: nfkc decompose' do
+      let(:normalizer) { ICU::Normalizer.new(nil, 'nfkc', :decompose) }
+
+      it "should normalize a string" do
+        normalizer.normalize("Äffin").unpack("U*").should == [65, 776, 102, 102, 105, 110]
+        normalizer.normalize("Äﬃn").unpack("U*").should == [65, 776, 102, 102, 105, 110]
+        normalizer.normalize("Henry IV").unpack("U*").should == [72, 101, 110, 114, 121, 32, 73, 86]
+        normalizer.normalize("Henry Ⅳ").unpack("U*").should == [72, 101, 110, 114, 121, 32, 73, 86]
+      end
+    end
+
+    describe 'NFKC: nfkc compose' do
+      let(:normalizer) { ICU::Normalizer.new(nil, 'nfkc', :compose) }
+
+      it "should normalize a string" do
+        normalizer.normalize("Äffin").unpack("U*").should == [196, 102, 102, 105, 110]
+        normalizer.normalize("Äﬃn").unpack("U*").should == [196, 102, 102, 105, 110]
+        normalizer.normalize("Henry IV").unpack("U*").should == [72, 101, 110, 114, 121, 32, 73, 86]
+        normalizer.normalize("Henry Ⅳ").unpack("U*").should == [72, 101, 110, 114, 121, 32, 73, 86]
+      end
+    end
+  end # Normalizer
+end # ICU


### PR DESCRIPTION
https://ssl.icu-project.org/apiref/icu4c/unorm2_8h.html

`unorm_*` is already deprecated and only a layer to the new API.

Here is the new API binding.